### PR TITLE
fixes #52 

### DIFF
--- a/start.py
+++ b/start.py
@@ -118,10 +118,17 @@ def remove_model_docker(docker_id):
 
 def start_docker(args):
     docker_id = get_init_value(args.model, "docker_id")
-    config = get_model_info_from_index(args.model)
+    try:
+        config = get_model_info_from_index(args.model)
+        if "gpu" in config:
+            gpu = True
+    except KeyError as e:
+        print(e)
+        print("Falling back to CPU for local model.")
+        gpu = False
     if args.updatedocker:
         remove_model_docker(docker_id)
-    if "gpu" in config:
+    if gpu:
         command = ("docker run -it --rm --runtime=nvidia " + get_port_mapping_cmd(args) + " "
                + get_contrib_src_mount_cmd(args) + " "
                + get_local_framework_mount_cmd(args) + " "

--- a/start.py
+++ b/start.py
@@ -153,7 +153,7 @@ def check_gpu_mode(args):
             gpu = True
     except KeyError as e:
         print(e)
-        print("Falling back to CPU mode for local model.")
+        print("Attention: Falling back to CPU mode for local model.")
     return gpu
 
 def convert_to_github_api_contents_req(url, branch_id):


### PR DESCRIPTION
Fixes the GPU mode error ( modelhub-ai/modelhub#52 )when testing models locally during development. Catches 'model not found in online index' exceptions and falls back to CPU. 
adds a new program argument -g to allow for GPU based testing which overrides the automatic check with the model index above. 